### PR TITLE
Added ignoreScripts option for safe installation

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ module.exports = {
 		var cmdString = "npm install " + packages.join(" ") + " "
 		+ (opts.global ? " -g":"")
 		+ (opts.save   ? " --save":"")
-		+ (opts.saveDev? " --saveDev":"");
+		+ (opts.saveDev? " --saveDev":"")
+		+ (opts.ignoreScripts? " --ignore-scripts":"");
 
 		return new Promise(function(resolve, reject){
 			var cmd = exec(cmdString, {cwd: opts.cwd?opts.cwd:"/"},(error, stdout, stderr) => {


### PR DESCRIPTION
The default behavior of npm is to execute the prepublish scripts of the package.
With the ignoreScripts option, this can be disabled so that packages can securely be installed on a server system.

This is really important for automatically installed packages that are controlled by the users.
