### PR TITLE
(feat): Added the ability to save exact

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If output is set, the output of npm will be shown in the console.
 | Name        | Type           | Value  |
 | ------------- |:-------------:| -----:|
 | packages      | Array      |   packages to be installed |
-| opts      | Object | save:true/false; global:true/false; cwd:string; saveDev:true/false; noOptional:true/false; legacyBundling: true/false; output:true/false|
+| opts      | Object | save:true/false; global:true/false; cwd:string; saveDev:true/false; noOptional:true/false; legacyBundling: true/false; output:true/false, saveExact:true/false|
 
 ### Example
 ``` 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
 		+ (opts.saveDev? " --save-dev":"")
 		+ (opts.legacyBundling? " --legacy-bundling":"")
 		+ (opts.noOptional? " --no-optional":"")
+		+ (opts.saveExact? " --save-exact":"")
 		+ (opts.ignoreScripts? " --ignore-scripts":"");
 
 		return new Promise(function(resolve, reject){


### PR DESCRIPTION
From npm-install page: https://docs.npmjs.com/cli/install

`-E, --save-exact`: Saved dependencies will be configured with an exact version rather than using npm’s default semver range operator.