### PR TITLE
Fixed #25 CVE-2020-7614 command injection issue, fixed package list parsing and more

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ module.exports = {
 	list:function(path){
 		var global = false;
 		if(!path) global = true;
-		var cmdArgs = ["ls", "--depth=0"];
+		var cmdArgs = ["ls", "--depth=0", "--json"];
     global && cmdArgs.push("-g");
 		return new Promise(function(resolve, reject){
 			execFile(cmdFile, cmdArgs, {cwd: path?path:"/"},(error, stdout, stderr) => {
@@ -88,19 +88,7 @@ module.exports = {
 						return reject(error);
 					}
 				}
-				var packages = [];
-				packages = stdout.split('\n');
-				packages = packages.filter(function(item){
-					if(item.match(/^(\+|`)--.+/g) != null){
-						return true
-					}
-					return undefined;
-				});
-				packages = packages.map(function(item){
-					if(item.match(/^(\+|`)--\s.+/g) != null){
-						return item.replace(/^(\+|`)--\s/g, "");
-					}
-				})
+				const packages = Object.keys(JSON.parse(stdout).dependencies);
 				resolve(packages);
 
 			});


### PR DESCRIPTION
- fixed #25 `CVE-2020-7614` command injection issue by using `require('child_process').execFile()` instead of `require('child_process').exec()` and passing parameters as separate strings
- fixed package list parsing for npm (tested on `npm@6.14.8`)
- fixed `--save-dev` issue on uninstall, being passed as incorrect `--saveDev`
- refactored some code